### PR TITLE
Port to python3 and new buildout version

### DIFF
--- a/buildout/dumprequirements/__init__.py
+++ b/buildout/dumprequirements/__init__.py
@@ -60,7 +60,7 @@ def dump_picked_versions(old_logging_shutdown, file_name, overwrite):
                 print("Overwriting %s" % file_name)
                 print("*********************************************")
                 open(file_name, 'w').write(picked_versions)
-            else:    
+            else:
                 print("*********************************************")
                 print("Skipped: File %s already exists." % file_name)
                 print("*********************************************")
@@ -69,16 +69,15 @@ def dump_picked_versions(old_logging_shutdown, file_name, overwrite):
             print(picked_versions)
             print("*************** /PICKED VERSIONS ***************")
 
-        old_logging_shutdown()    
+        old_logging_shutdown()
     return logging_shutdown
 
 
 def install(buildout):
-
     file_name = 'dump-requirements-file' in buildout['buildout'] and \
                 buildout['buildout']['dump-requirements-file'].strip() or \
                 None
-                
+
     overwrite = 'overwrite-requirements-file' not in buildout['buildout'] or \
                 buildout['buildout']['overwrite-requirements-file'].lower() \
                 in ['yes', 'true', 'on']
@@ -86,9 +85,8 @@ def install(buildout):
     zc.buildout.easy_install.Installer.__all_picked_versions = {}
     zc.buildout.easy_install._log_requirement = _log_requirement
     zc.buildout.easy_install.Installer._get_dist = enable_dumping_picked_versions(
-                                  zc.buildout.easy_install.Installer._get_dist)
-    
-    logging.shutdown = dump_picked_versions(logging.shutdown, 
-                                            file_name, 
+                                 zc.buildout.easy_install.Installer._get_dist)
+
+    logging.shutdown = dump_picked_versions(logging.shutdown,
+                                            file_name,
                                             overwrite)
-    

--- a/buildout/dumprequirements/__init__.py
+++ b/buildout/dumprequirements/__init__.py
@@ -52,23 +52,23 @@ def dump_picked_versions(old_logging_shutdown, file_name, overwrite):
 
         if file_name is not None:
             if not os.path.exists(file_name):
-                print "*********************************************"
-                print "Writing picked versions to %s" % file_name
-                print "*********************************************"
+                print("*********************************************")
+                print("Writing picked versions to %s" % file_name)
+                print("*********************************************")
                 open(file_name, 'w').write(picked_versions)
             elif overwrite:
-                print "*********************************************"
-                print "Overwriting %s" % file_name
-                print "*********************************************"
+                print("*********************************************")
+                print("Overwriting %s" % file_name)
+                print("*********************************************")
                 open(file_name, 'w').write(picked_versions)
             else:    
-                print "*********************************************"
-                print "Skipped: File %s already exists." % file_name                 
-                print "*********************************************"
+                print("*********************************************")
+                print("Skipped: File %s already exists." % file_name)
+                print("*********************************************")
         else:
-            print "*************** PICKED VERSIONS ****************"
-            print picked_versions
-            print "*************** /PICKED VERSIONS ***************"
+            print("*************** PICKED VERSIONS ****************")
+            print(picked_versions)
+            print("*************** /PICKED VERSIONS ***************")
 
         old_logging_shutdown()    
     return logging_shutdown

--- a/buildout/dumprequirements/__init__.py
+++ b/buildout/dumprequirements/__init__.py
@@ -23,15 +23,14 @@ def _log_requirement(ws, req):
 
 
 def enable_dumping_picked_versions(old_get_dist):
-    def get_dist(self, requirement, ws, always_unzip):
-        dists = old_get_dist(self, requirement, ws, always_unzip)
+    def get_dist(self, *args, **kwargs):
+        dists = old_get_dist(self, *args, **kwargs)
+
         for dist in dists:
-            if not (dist.precedence == pkg_resources.DEVELOP_DIST or \
-                    (len(requirement.specs) == 1 and requirement.specs[0][0] == '==')):
-                self.__picked_versions[dist.project_name] = dist.version
-            if not (dist.precedence == pkg_resources.DEVELOP_DIST):
-                self.__all_picked_versions[dist.project_name] = dist.version
-        return dists        
+            if not (dist.precedence == pkg_resources.DEVELOP_DIST) and \
+               not kwargs.get('for_buildout_run', False):
+                    self.__all_picked_versions[dist.project_name] = dist.version
+        return dists
     return get_dist
 
 
@@ -84,7 +83,6 @@ def install(buildout):
                 buildout['buildout']['overwrite-requirements-file'].lower() \
                 in ['yes', 'true', 'on']
 
-    zc.buildout.easy_install.Installer.__picked_versions = {}
     zc.buildout.easy_install.Installer.__all_picked_versions = {}
     zc.buildout.easy_install._log_requirement = _log_requirement
     zc.buildout.easy_install.Installer._get_dist = enable_dumping_picked_versions(


### PR DESCRIPTION
I am using buildout 2.3.1 with python 3.4.0 and in order to get buildout.dumprequirements working I did a few changes. This could maybe also be useful for other users. I tried to maintain backward compatibility.
